### PR TITLE
Fix Collar of Pain lagging upon using /kill

### DIFF
--- a/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
+++ b/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
@@ -513,11 +513,13 @@ public class FMEventHandler {
             ItemStack amulet = BaublesApi.getBaubles(player).getStackInSlot(0);
             if (amulet != null && amulet.getItem() == ForbiddenItems.subCollar) {
                 int doses = 3 * (int) event.ammount;
+                float max_doses = 3 * event.entityLiving.getHealth();
                 if (event.source.getEntity() != null && event.source.getEntity() instanceof EntityPlayer) {
                     EntityPlayer dom = (EntityPlayer) event.source.getEntity();
                     int chance = 1;
                     if (dom.getHeldItem() != null && dom.getHeldItem().getItem() instanceof ItemRidingCrop) {
                         doses += 3;
+                        max_doses += 3;
                         chance += 3;
                     }
                     if (player.worldObj.provider.dimensionId == -1 && randy.nextInt(30) < chance) {
@@ -528,7 +530,7 @@ public class FMEventHandler {
                     }
                 }
                 ItemSubCollar collar = ((ItemSubCollar) ForbiddenItems.subCollar);
-                for (int x = 0; x < Math.min(doses, 3 * event.entityLiving.getHealth()); x++) {
+                for (int x = 0; x < Math.min(doses, max_doses); x++) {
                     collar.addVis(amulet, primals[randy.nextInt(6)], 1, true);
                 }
             }

--- a/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
+++ b/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
@@ -513,13 +513,11 @@ public class FMEventHandler {
             ItemStack amulet = BaublesApi.getBaubles(player).getStackInSlot(0);
             if (amulet != null && amulet.getItem() == ForbiddenItems.subCollar) {
                 int doses = 3 * (int) Math.min(event.ammount, event.entityLiving.getHealth());
-                float max_doses = 3 * event.entityLiving.getHealth();
                 if (event.source.getEntity() != null && event.source.getEntity() instanceof EntityPlayer) {
                     EntityPlayer dom = (EntityPlayer) event.source.getEntity();
                     int chance = 1;
                     if (dom.getHeldItem() != null && dom.getHeldItem().getItem() instanceof ItemRidingCrop) {
                         doses += 3;
-                        max_doses += 3;
                         chance += 3;
                     }
                     if (player.worldObj.provider.dimensionId == -1 && randy.nextInt(30) < chance) {
@@ -530,7 +528,7 @@ public class FMEventHandler {
                     }
                 }
                 ItemSubCollar collar = ((ItemSubCollar) ForbiddenItems.subCollar);
-                for (int x = 0; x < Math.min(doses, max_doses); x++) {
+                for (int x = 0; x < doses; x++) {
                     collar.addVis(amulet, primals[randy.nextInt(6)], 1, true);
                 }
             }

--- a/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
+++ b/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
@@ -527,8 +527,9 @@ public class FMEventHandler {
                         ent.motionZ += (player.worldObj.rand.nextFloat() - player.worldObj.rand.nextFloat()) * 0.1F;
                     }
                 }
-                for (int x = 0; x < doses; x++) {
-                    ((ItemSubCollar) ForbiddenItems.subCollar).addVis(amulet, primals[randy.nextInt(6)], 1, true);
+                ItemSubCollar collar = ((ItemSubCollar) ForbiddenItems.subCollar);
+                for (int x = 0; x < Math.min(doses, event.entityLiving.getHealth()); x++) {
+                    collar.addVis(amulet, primals[randy.nextInt(6)], 1, true);
                 }
             }
         }

--- a/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
+++ b/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
@@ -512,7 +512,7 @@ public class FMEventHandler {
             EntityPlayer player = (EntityPlayer) event.entityLiving;
             ItemStack amulet = BaublesApi.getBaubles(player).getStackInSlot(0);
             if (amulet != null && amulet.getItem() == ForbiddenItems.subCollar) {
-                int doses = 3 * (int) event.ammount;
+                int doses = 3 * (int) Math.min(event.ammount, event.entityLiving.getHealth());
                 float max_doses = 3 * event.entityLiving.getHealth();
                 if (event.source.getEntity() != null && event.source.getEntity() instanceof EntityPlayer) {
                     EntityPlayer dom = (EntityPlayer) event.source.getEntity();

--- a/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
+++ b/src/main/java/fox/spiteful/forbidden/FMEventHandler.java
@@ -528,7 +528,7 @@ public class FMEventHandler {
                     }
                 }
                 ItemSubCollar collar = ((ItemSubCollar) ForbiddenItems.subCollar);
-                for (int x = 0; x < Math.min(doses, event.entityLiving.getHealth()); x++) {
+                for (int x = 0; x < Math.min(doses, 3 * event.entityLiving.getHealth()); x++) {
                     collar.addVis(amulet, primals[randy.nextInt(6)], 1, true);
                 }
             }


### PR DESCRIPTION
Since /kill is coded to deal a ton of damage, the Collar of Pain ends up lagging the server and also has the side effect of fully charging it. Minimizing the amount of loops to the player's health fixes both issues.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20486