### PR TITLE
Match burned out Profane Wand vis cost with non-burned out Wand

### DIFF
--- a/src/main/java/fox/spiteful/forbidden/items/ForbiddenItems.java
+++ b/src/main/java/fox/spiteful/forbidden/items/ForbiddenItems.java
@@ -215,7 +215,7 @@ public class ForbiddenItems {
                 "profaned",
                 50,
                 new ItemStack(Blocks.bedrock, 1),
-                1000,
+                12,
                 new ResourceLocation("forbidden", "textures/models/wand_rod_profaned.png"));
         STAFF_ROD_BLOOD = new StaffRod(
                 "blood",


### PR DESCRIPTION
Fixes a niche situation when trying to substitute wand caps for a fully burnt out Profane Wand.