### PR TITLE
Fix Wand Metadata

### DIFF
--- a/src/main/java/fox/spiteful/forbidden/VillagerHereticManager.java
+++ b/src/main/java/fox/spiteful/forbidden/VillagerHereticManager.java
@@ -72,7 +72,10 @@ public class VillagerHereticManager implements IVillageTradeHandler {
                             new ItemStack(Items.emerald, 1),
                             new ItemStack(Items.glowstone_dust, 8 + random.nextInt(9))));
 
-            ItemStack wand = new ItemStack(ConfigItems.itemWandCasting, 1, 36);
+            ItemStack wand = new ItemStack(
+                    ConfigItems.itemWandCasting,
+                    1,
+                    ConfigItems.WAND_CAP_IRON.getCraftCost() * ForbiddenItems.WAND_ROD_PROFANE.getCraftCost());
             ((ItemWandCasting) wand.getItem()).setCap(wand, ConfigItems.WAND_CAP_IRON);
             ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_PROFANE);
             ((ItemWandCasting) wand.getItem()).storeAllVis(

--- a/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCores.java
+++ b/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCores.java
@@ -16,6 +16,8 @@ import fox.spiteful.forbidden.compat.Compat;
 import fox.spiteful.forbidden.items.ForbiddenItems;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.wands.WandCap;
+import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
@@ -48,79 +50,48 @@ public class ItemWandCores extends Item {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void getSubItems(Item item, CreativeTabs xCreativeTabs, List list) {
+    public void getSubItems(Item item, CreativeTabs xCreativeTabs, List<ItemStack> list) {
         for (int x = 0; x < types.length; x++) {
             list.add(new ItemStack(this, 1, x));
         }
 
-        ItemStack wand = new ItemStack(ConfigItems.itemWandCasting, 1, 72);
-        ((ItemWandCasting) wand.getItem()).setCap(wand, ConfigItems.WAND_CAP_THAUMIUM);
-        ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_TAINTED);
-        list.add(wand);
-        wand = new ItemStack(ConfigItems.itemWandCasting, 1, 72);
-        ((ItemWandCasting) wand.getItem()).setCap(wand, ConfigItems.WAND_CAP_THAUMIUM);
-        ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_INFERNAL);
-        list.add(wand);
-        wand = new ItemStack(ConfigItems.itemWandCasting, 1, 2000);
-        ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_ORICHALCUM);
-        ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_NEUTRONIUM);
-        list.add(wand);
-        wand = new ItemStack(ConfigItems.itemWandCasting, 1, 2000);
-        ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_ORICHALCUM);
-        ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.STAFF_ROD_NEUTRONIUM);
-        list.add(wand);
-        wand = new ItemStack(ConfigItems.itemWandCasting, 1, 36);
-        ((ItemWandCasting) wand.getItem()).setCap(wand, ConfigItems.WAND_CAP_IRON);
-        ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_PROFANE);
+        list.add(buildWand(ConfigItems.WAND_CAP_THAUMIUM, ForbiddenItems.WAND_ROD_TAINTED));
+        list.add(buildWand(ConfigItems.WAND_CAP_THAUMIUM, ForbiddenItems.WAND_ROD_INFERNAL));
+        list.add(buildWand(ForbiddenItems.WAND_CAP_ORICHALCUM, ForbiddenItems.WAND_ROD_NEUTRONIUM));
+        list.add(buildWand(ForbiddenItems.WAND_CAP_ORICHALCUM, ForbiddenItems.STAFF_ROD_NEUTRONIUM));
+        ItemStack wand = buildWand(ConfigItems.WAND_CAP_IRON, ForbiddenItems.WAND_ROD_PROFANE);
         ((ItemWandCasting) wand.getItem()).storeAllVis(
                 wand,
                 new AspectList().add(Aspect.FIRE, 5000).add(Aspect.WATER, 5000).add(Aspect.EARTH, 5000)
                         .add(Aspect.AIR, 5000).add(Aspect.ORDER, 5000).add(Aspect.ENTROPY, 5000));
         list.add(wand);
         if (Compat.bm && Config.crossWand) {
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 84);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_ALCHEMICAL);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_BLOOD);
-            list.add(wand);
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 168);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_ALCHEMICAL);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.STAFF_ROD_BLOOD);
-            list.add(wand);
+            list.add(buildWand(ForbiddenItems.WAND_CAP_ALCHEMICAL, ForbiddenItems.WAND_ROD_BLOOD));
+            list.add(buildWand(ForbiddenItems.WAND_CAP_ALCHEMICAL, ForbiddenItems.STAFF_ROD_BLOOD));
         }
         if (Compat.am2 && Config.crossWand) {
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 72);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_VINTEUM);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_WITCHWOOD);
-            list.add(wand);
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 144);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_VINTEUM);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.STAFF_ROD_WITCHWOOD);
-            list.add(wand);
+            list.add(buildWand(ForbiddenItems.WAND_CAP_VINTEUM, ForbiddenItems.WAND_ROD_WITCHWOOD));
+            list.add(buildWand(ForbiddenItems.WAND_CAP_VINTEUM, ForbiddenItems.STAFF_ROD_WITCHWOOD));
         }
         if (Compat.botan && Config.crossWand) {
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 84);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_MANASTEEL);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_LIVINGWOOD);
-            list.add(wand);
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 84);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_ELEMENTIUM);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_DREAMWOOD);
-            list.add(wand);
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 144);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_ELEMENTIUM);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.STAFF_ROD_DREAMWOOD);
-            list.add(wand);
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 1);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ForbiddenItems.WAND_CAP_TERRASTEEL);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ConfigItems.WAND_ROD_WOOD);
-            list.add(wand);
+            list.add(buildWand(ForbiddenItems.WAND_CAP_MANASTEEL, ForbiddenItems.WAND_ROD_LIVINGWOOD));
+            list.add(buildWand(ForbiddenItems.WAND_CAP_ELEMENTIUM, ForbiddenItems.WAND_ROD_DREAMWOOD));
+            list.add(buildWand(ForbiddenItems.WAND_CAP_ELEMENTIUM, ForbiddenItems.STAFF_ROD_DREAMWOOD));
+            list.add(buildWand(ForbiddenItems.WAND_CAP_TERRASTEEL, ConfigItems.WAND_ROD_WOOD));
         }
         if (Compat.ee3 && Config.crossWand) {
-            wand = new ItemStack(ConfigItems.itemWandCasting, 1, 84);
-            ((ItemWandCasting) wand.getItem()).setCap(wand, ConfigItems.WAND_CAP_VOID);
-            ((ItemWandCasting) wand.getItem()).setRod(wand, ForbiddenItems.WAND_ROD_EQUIVALENT);
-            list.add(wand);
+            list.add(buildWand(ConfigItems.WAND_CAP_VOID, ForbiddenItems.WAND_ROD_EQUIVALENT));
         }
+    }
+
+    private static ItemStack buildWand(WandCap cap, WandRod rod) {
+        ItemStack wand = new ItemStack(
+                ConfigItems.itemWandCasting,
+                1,
+                Math.min(rod.getCraftCost() * cap.getCraftCost(), Short.MAX_VALUE - 1));
+        ((ItemWandCasting) wand.getItem()).setCap(wand, cap);
+        ((ItemWandCasting) wand.getItem()).setRod(wand, rod);
+        return wand;
     }
 
     @Override

--- a/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCores.java
+++ b/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCores.java
@@ -65,21 +65,22 @@ public class ItemWandCores extends Item {
                 new AspectList().add(Aspect.FIRE, 5000).add(Aspect.WATER, 5000).add(Aspect.EARTH, 5000)
                         .add(Aspect.AIR, 5000).add(Aspect.ORDER, 5000).add(Aspect.ENTROPY, 5000));
         list.add(wand);
-        if (Compat.bm && Config.crossWand) {
+        if (!Config.crossWand) return;
+        if (Compat.bm) {
             list.add(buildWand(ForbiddenItems.WAND_CAP_ALCHEMICAL, ForbiddenItems.WAND_ROD_BLOOD));
             list.add(buildWand(ForbiddenItems.WAND_CAP_ALCHEMICAL, ForbiddenItems.STAFF_ROD_BLOOD));
         }
-        if (Compat.am2 && Config.crossWand) {
+        if (Compat.am2) {
             list.add(buildWand(ForbiddenItems.WAND_CAP_VINTEUM, ForbiddenItems.WAND_ROD_WITCHWOOD));
             list.add(buildWand(ForbiddenItems.WAND_CAP_VINTEUM, ForbiddenItems.STAFF_ROD_WITCHWOOD));
         }
-        if (Compat.botan && Config.crossWand) {
+        if (Compat.botan) {
             list.add(buildWand(ForbiddenItems.WAND_CAP_MANASTEEL, ForbiddenItems.WAND_ROD_LIVINGWOOD));
             list.add(buildWand(ForbiddenItems.WAND_CAP_ELEMENTIUM, ForbiddenItems.WAND_ROD_DREAMWOOD));
             list.add(buildWand(ForbiddenItems.WAND_CAP_ELEMENTIUM, ForbiddenItems.STAFF_ROD_DREAMWOOD));
             list.add(buildWand(ForbiddenItems.WAND_CAP_TERRASTEEL, ConfigItems.WAND_ROD_WOOD));
         }
-        if (Compat.ee3 && Config.crossWand) {
+        if (Compat.ee3) {
             list.add(buildWand(ConfigItems.WAND_CAP_VOID, ForbiddenItems.WAND_ROD_EQUIVALENT));
         }
     }


### PR DESCRIPTION
The metadata of a wand is supposed to be its core cost * cap cost. This fixes that and simplifies the logic that adds wands to NEI/the creative menu.