### PR TITLE
Array Index Guard

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,26 +1,14 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.9.41:dev")
-    api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
-    api('com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev')
-    api("com.github.GTNewHorizons:GTNHLib:0.9.31:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.10.8:dev")
+    api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
+    api("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev")
 
-    compileOnly('com.github.GTNewHorizons:BloodMagic:1.8.12:dev')
-    compileOnly('com.github.GTNewHorizons:Botania:1.13.15-GTNH:api')
-    compileOnly("com.github.GTNewHorizons:AppleCore:3.3.9:dev")
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.9.4:dev")
+    compileOnly("com.github.GTNewHorizons:Botania:1.13.21-GTNH:api")
+    compileOnly("com.github.GTNewHorizons:AppleCore:3.3.11:dev")
+    compileOnly("curse.maven:ee3-65509:2305023")
 
-
-    compileOnly('curse.maven:ee3-65509:2305023')
-
-    // deps may transitively add Baubles, so we replace it
-    project.getConfigurations()
-            .all(c -> {
-                final DependencySubstitutions ds = c.getResolutionStrategy()
-                        .getDependencySubstitution();
-                ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
-                        .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH"))
-                        .withClassifier("dev")
-                        .because("Baubles-Expanded replaces Baubles");
-            });
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:AspectRecipeIndex:1.1.0:dev")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '2.0.20'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '2.0.24'
 }
 
 

--- a/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCaps.java
+++ b/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCaps.java
@@ -35,12 +35,13 @@ public class ItemWandCaps extends Item {
     @SideOnly(Side.CLIENT)
     @Override
     public IIcon getIconFromDamage(int meta) {
+        if (meta >= icon.length) meta = 0;
         return this.icon[meta];
     }
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void getSubItems(Item item, CreativeTabs xCreativeTabs, List list) {
+    public void getSubItems(Item item, CreativeTabs xCreativeTabs, List<ItemStack> list) {
         for (int x = 0; x < types.length; x++) {
             list.add(new ItemStack(this, 1, x));
         }
@@ -48,6 +49,8 @@ public class ItemWandCaps extends Item {
 
     @Override
     public String getUnlocalizedName(ItemStack stack) {
-        return super.getUnlocalizedName() + "." + types[stack.getItemDamage()];
+        int meta = stack.getItemDamage();
+        if (meta >= types.length) meta = 0;
+        return super.getUnlocalizedName() + "." + types[meta];
     }
 }

--- a/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCores.java
+++ b/src/main/java/fox/spiteful/forbidden/items/wands/ItemWandCores.java
@@ -45,6 +45,7 @@ public class ItemWandCores extends Item {
     @SideOnly(Side.CLIENT)
     @Override
     public IIcon getIconFromDamage(int meta) {
+        if (meta >= icon.length) meta = 0;
         return this.icon[meta];
     }
 
@@ -97,6 +98,8 @@ public class ItemWandCores extends Item {
 
     @Override
     public String getUnlocalizedName(ItemStack stack) {
-        return super.getUnlocalizedName() + "." + types[stack.getItemDamage()];
+        int meta = stack.getItemDamage();
+        if (meta >= types.length) meta = 0;
+        return super.getUnlocalizedName() + "." + types[meta];
     }
 }


### PR DESCRIPTION
Guard against crashes caused by invalid metadata for wand cores/caps by showing name/icon for meta 0
<img width="648" height="190" alt="image" src="https://github.com/user-attachments/assets/ef5145a9-4cb2-4056-8b9f-3e70265609b8" />
<img width="641" height="139" alt="image" src="https://github.com/user-attachments/assets/5e1ef82b-41e7-4559-83f0-ac445da80382" />
